### PR TITLE
Replace [ ] with ( ) for external link on Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ public void onPageSelected(int position) {
 # Apps Using SmartTabLayout
 
 * [Qiitanium][qiitanium]
-* [Ameba][https://play.google.com/store/apps/details?id=jp.ameba&hl=ja]
+* [Ameba](https://play.google.com/store/apps/details?id=jp.ameba&hl=ja)
 
 # LICENSE
 


### PR DESCRIPTION
I'm sorry that I mistakenly used [ ] for wrapping external link url in the previous pull request; those [ ] should be ( ).