### PR TITLE
Fix indicator position of auto_center

### DIFF
--- a/library/src/main/java/com/ogaclejapan/smarttablayout/SmartTabLayout.java
+++ b/library/src/main/java/com/ogaclejapan/smarttablayout/SmartTabLayout.java
@@ -463,8 +463,10 @@ public class SmartTabLayout extends HorizontalScrollView {
 
       if (isLayoutRtl) {
         x = -Utils.getWidthWithMargin(selectedTab) / 2 + getWidth() / 2;
+        x -= Utils.getPaddingStart(this);
       } else {
         x = Utils.getWidthWithMargin(selectedTab) / 2 - getWidth() / 2;
+        x += Utils.getPaddingStart(this);
       }
 
     } else {


### PR DESCRIPTION
When SmartTaLayout has auto_center and padding attributes like below, 
```
<com.ogaclejapan.smarttablayout.SmartTabLayout
    ...
    android:paddingLeft="20dp"
    android:paddingRight="20dp"
    android:clipToPadding="false"
    app:stl_titleOffset="auto_center"
    />
```
The position of the indicator is located to the right.
![before](https://cloud.githubusercontent.com/assets/9046837/11497158/769c809c-985a-11e5-96fb-610ec4a2d730.png)
