### PR TITLE
Implemented setting a listener to set up the views, once they are ready.

### DIFF
--- a/utils-v4/src/main/java/com/ogaclejapan/smarttablayout/utils/ViewPagerItemAdapter.java
+++ b/utils-v4/src/main/java/com/ogaclejapan/smarttablayout/utils/ViewPagerItemAdapter.java
@@ -28,11 +28,24 @@ public class ViewPagerItemAdapter extends PagerAdapter {
   private final ViewPagerItems pages;
   private final SparseArrayCompat<WeakReference<View>> holder;
   private final LayoutInflater inflater;
+  private final OnViewsStateChangedListener delegate;
+
+  public interface OnViewsStateChangedListener{
+    public void onAllViewsReady();
+  }
 
   public ViewPagerItemAdapter(ViewPagerItems pages) {
     this.pages = pages;
     this.holder = new SparseArrayCompat<>(pages.size());
     this.inflater = LayoutInflater.from(pages.getContext());
+  }
+  // used if the client wants to attach a listener, to be called once the views are
+  // ready to be set-up
+  public ViewPagerITemAdapter(ViewPagerItems pages, OnViewsStateChangedListener delegate ){
+    this.pages = pages;
+    this.holder = new SparseArrayCompat<>(pages.size());
+    this.inflater = LayoutInflater.from(pages.getContext());
+    this.delegate = delegate;
   }
 
   @Override
@@ -45,6 +58,9 @@ public class ViewPagerItemAdapter extends PagerAdapter {
     View view = getPagerItem(position).initiate(inflater, container);
     container.addView(view);
     holder.put(position, new WeakReference<View>(view));
+    if(position == this.pages.size() - 1) // we reached the last view
+      if(delegate != null)
+        delegate.onAllViewsReady();
     return view;
   }
 


### PR DESCRIPTION
I was using the v4 utility to add a tab-bar to a fragment using views. I wanted to set some callbacks to some child-views of the views I passed to the ViewPagerItemAdapter as ViewPagerItems. But, whenever I try to call the getPage(position) method, it returns a null reference. I dived into the source code, and realized that I am calling it too early.

 So, I added a new interface and a new constructor, to set up a listener to setup the views once they are ready.