### PR TITLE
#162 Fix black cicle indicator for Samsung Galaxy S Duos GT-S7562

### DIFF
--- a/demo/src/main/res/drawable/custom_circle.xml
+++ b/demo/src/main/res/drawable/custom_circle.xml
@@ -3,6 +3,9 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   android:shape="oval"
   >
+
+  <solid android:color="@android:color/transparent"/>
+
   <stroke
     android:width="1dp"
     android:color="@color/icon_disabled"


### PR DESCRIPTION
As result:
![device-2016-05-04-121006](https://cloud.githubusercontent.com/assets/2806586/15005618/cea75174-11e8-11e6-97eb-42cf0d00a390.png)
